### PR TITLE
:bug: Change file directory in `streamlit_viz_csv.py`

### DIFF
--- a/src/utils/streamlit_viz_csv.py
+++ b/src/utils/streamlit_viz_csv.py
@@ -6,7 +6,7 @@ import pandas as pd
 import streamlit as st
 from pycocotools.coco import COCO
 
-CSV_DIR = "/opt/ml/level2_semanticsegmentation_cv-level2-cv-17/src/submission/"
+CSV_DIR = "/opt/ml/input/code/submission/"
 
 
 @st.cache


### PR DESCRIPTION
Submission 파일의 디렉터리를 `~/level2_semanticsegmentation_cv-level2-cv-17/src/submission/`에서 `~/input/code/submission/`으로 변경했습니다.
Submission 파일을 생성하면 파일을 이동하지 않고 바로 볼 수 있습니다.